### PR TITLE
Initial code for etcd role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+etcd Ansible role
+=================
+
+Install and configured a etcd service.
+
+Role Tags
+---------
+
+ * install
+ * configure
+ * deploy
+ * test
+
+Role Variables
+--------------
+
+See defaults/main.yml
+
+Example Playbook
+----------------
+
+
+    - hosts: localhost
+      roles:
+         - role: etcd
+           etcd_client_port: 2379
+           etcd_peer_port: 2380
+
+License
+-------
+
+Apache 2.0
+
+Author Information
+------------------
+
+Based on https://github.com/kubernetes/contrib/ansible/roles/etcd

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example Playbook
 License
 -------
 
-Apache 2.0
+MIT
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+
+etcd_client_port: 2379
+etcd_peer_port: 2380
+etcd_peers_group: etcd
+etcd_url_scheme: http
+etcd_peer_url_scheme: http
+
+etcd_conf_dir: /etc/etcd
+etcd_data_dir: /var/lib/etcd
+
+etcd_ca_file: "{{ etcd_conf_dir }}/tls/ca.crt"
+etcd_cert_file: "{{ etcd_conf_dir }}/tls/server.crt"
+etcd_key_file: "{{ etcd_conf_dir }}/tls/server.key"
+etcd_peer_ca_file: "{{ etcd_conf_dir }}/tls/ca.crt"
+etcd_peer_cert_file: "{{ etcd_conf_dir }}/tls/peer.crt"
+etcd_peer_key_file: "{{ etcd_conf_dir }}/tls/peer.key"
+
+etcd_initial_cluster_state: new
+etcd_initial_cluster_token: etcd-k8-cluster
+
+etcd_snapshot_counter: 10000
+etcd_heartbeat_interval: 100
+etcd_election_timeout: 1000
+etcd_max_snapshots: 5
+etcd_max_wals: 5
+etcd_cors: ''
+
+etcd_listen_peer_urls: "{{ etcd_peer_url_scheme }}://0.0.0.0:{{ etcd_peer_port }}"
+etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ ansible_fqdn }}:{{ etcd_client_port }}"
+etcd_listen_client_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,4 @@
 ---
-- name: reload systemd
-  command: systemctl --system daemon-reload
 
 - name: restart etcd
   service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: reload systemd
+  command: systemctl --system daemon-reload
+
+- name: restart etcd
+  service:
+    name: etcd
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: Giovanni Tirloni
+  description: Ansible role for etcd key-value store
+  company: Inclusive Design Research Centre, OCAD University
+  license: MIT
+  min_ansible_version: 1.9.4
+  platforms:
+  - name: EL
+    versions:
+    - 7
+dependencies: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Transfer etcd.conf
+  template:
+    src: etcd.conf.j2
+    dest: /etc/etcd/etcd.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart etcd

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Enable and start service
+  service:
+    name: etcd
+    enabled: yes
+    state: started

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,5 +2,6 @@
 
 - name: Install package
   yum:
-    name: etcd
+    name: "{{ item }}"
     state: latest
+  with_items: etcd_packages

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Install package
+  yum:
+    name: etcd
+    state: latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- include: install.yml
+  tags: ['install']
+
+- include: configure.yml
+  tags: ['configure']
+
+- include: deploy.yml
+  tags: ['deploy']
+
+- include: test.yml
+  tags: ['test']

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Wait for client port
+  wait_for:
+    host: 127.0.0.1
+    port: "{{ etcd_client_port }}"
+    delay: 5
+    timeout: 30
+
+- name: Check cluster health
+  command: /usr/bin/etcdctl cluster-health
+  changed_when: false

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -1,0 +1,52 @@
+{% macro initial_cluster() -%}
+{% for host in groups[etcd_peers_group] -%}
+{% if loop.last -%}
+{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_fqdn'] }}:{{ etcd_peer_port }}
+{%- else -%}
+{{ hostvars[host]['ansible_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['ansible_fqdn'] }}:{{ etcd_peer_port }},
+{%- endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 1 %}
+ETCD_NAME={{ ansible_hostname }}
+ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
+{% else %}
+ETCD_NAME=default
+{% endif %}
+ETCD_DATA_DIR={{ etcd_data_dir }}
+ETCD_SNAPSHOT_COUNTER="{{ etcd_snapshot_counter }}"
+ETCD_HEARTBEAT_INTERVAL="{{ etcd_heartbeat_interval }}"
+ETCD_ELECTION_TIMEOUT="{{ etcd_election_timeout }}"
+ETCD_LISTEN_CLIENT_URLS="{{ etcd_listen_client_urls }}"
+ETCD_MAX_SNAPSHOTS="{{ etcd_max_snapshots }}"
+ETCD_MAX_WALS="{{ etcd_max_wals }}"
+ETCD_CORS="{{ etcd_cors }}"
+
+{% if groups[etcd_peers_group] and groups[etcd_peers_group] | length > 1 %}
+#[cluster]
+ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
+ETCD_INITIAL_CLUSTER={{ initial_cluster() }}
+ETCD_INITIAL_CLUSTER_STATE={{ etcd_initial_cluster_state }}
+ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
+#ETCD_DISCOVERY=""
+#ETCD_DISCOVERY_SRV=""
+#ETCD_DISCOVERY_FALLBACK="proxy"
+#ETCD_DISCOVERY_PROXY=""
+{% endif %}
+ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
+
+#[proxy]
+#ETCD_PROXY="off"
+
+#[security]
+{% if etcd_url_scheme == 'https' -%}
+ETCD_CA_FILE={{ etcd_ca_file }}
+ETCD_CERT_FILE={{ etcd_cert_file }}
+ETCD_KEY_FILE={{ etcd_key_file }}
+{% endif -%}
+{% if etcd_peer_url_scheme == 'https' -%}
+ETCD_PEER_CA_FILE={{ etcd_peer_ca_file }}
+ETCD_PEER_CERT_FILE={{ etcd_peer_cert_file }}
+ETCD_PEER_KEY_FILE={{ etcd_peer_key_file }}
+{% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for etcd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for etcd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+etcd_packages:
+  - etcd


### PR DESCRIPTION
Nothing Earth shattering here. This is for the etcd servers that will be running outside Kubernetes and they're expected to run as systemd services. Kubernetes will deploy etcd containers itself later on (and manage them), but those are used for k8s-provided service (SkyDNS, etc).

A important missing piece is TLS configuration, which I will tackle this week. Would it be a good idea to generate a site-wide CA and store it in Ansible Vault to be used to generate client certs later on?

Tested on CentOS 7.1.
